### PR TITLE
Added some Recycling Recipes!

### DIFF
--- a/src/main/java/com/pansmith/steamadditions/common/data/SARecipes.java
+++ b/src/main/java/com/pansmith/steamadditions/common/data/SARecipes.java
@@ -3,6 +3,7 @@ package com.pansmith.steamadditions.common.data;
 import com.pansmith.steamadditions.data.recipe.*;
 import net.minecraft.data.recipes.FinishedRecipe;
 import com.pansmith.steamadditions.data.recipe.MiscRecipes;
+import com.pansmith.steamadditions.data.recipe.SARecyclingRecipes;
 
 import java.util.function.Consumer;
 
@@ -10,5 +11,6 @@ public class SARecipes {
 
     public static void init(Consumer<FinishedRecipe> provider) {
         MiscRecipes.init(provider);
+        SARecyclingRecipes.init(provider);
     }
 }

--- a/src/main/java/com/pansmith/steamadditions/data/recipe/SARecyclingRecipes.java
+++ b/src/main/java/com/pansmith/steamadditions/data/recipe/SARecyclingRecipes.java
@@ -1,14 +1,13 @@
-import com.gregtechceu.gtceu.data.recipe.misc.RecyclingRceipes;
-import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
-import com.gregtechceu.gtceu.api.data.chemical.material.stack.ItemMaterialInfo;
+import com.gregtechceu.gtceu.data.recipe.misc.RecyclingRecipes;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
+import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialStack;
 
 import com.pansmith.steamadditions.common.data.SAMachines;
 
 public class SARecyclingRecipes {
 
   public static void init(Consumer<FinishedRecipe> provider) {
-    ArrayList<MaterialStack> materialStacks = new ArrayList<>(new MaterialStack(GTMaterials.Bronze),new MaterialStack(GTMaterials.Brick));
+    ArrayList<MaterialStack> materialStacks = new ArrayList<>(new MaterialStack(GTMaterials.Bronze), new MaterialStack(GTMaterials.Brick));
     RecyclingRecipes.registerRecyclingRecipes‎(provider, SAMachines.STEAM_CENTRIFUGE.asStack(), materialStacks, false, null);
     RecyclingRecipes.registerRecyclingRecipes‎(provider, SAMachines.STEAM_ALLOY_SMELTER.asStack(), materialStacks, false, null);
   }

--- a/src/main/java/com/pansmith/steamadditions/data/recipe/SARecyclingRecipes.java
+++ b/src/main/java/com/pansmith/steamadditions/data/recipe/SARecyclingRecipes.java
@@ -1,0 +1,16 @@
+import com.gregtechceu.gtceu.data.recipe.misc.RecyclingRceipes;
+import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
+import com.gregtechceu.gtceu.api.data.chemical.material.stack.ItemMaterialInfo;
+import com.gregtechceu.gtceu.common.data.GTMaterials;
+
+import com.pansmith.steamadditions.common.data.SAMachines;
+
+public class SARecyclingRecipes {
+
+  public static void init(Consumer<FinishedRecipe> provider) {
+    ArrayList<MaterialStack> materialStacks = new ArrayList<>(new MaterialStack(GTMaterials.Bronze),new MaterialStack(GTMaterials.Brick));
+    RecyclingRecipes.registerRecyclingRecipes‎(provider, SAMachines.STEAM_CENTRIFUGE.asStack(), materialStacks, false, null);
+    RecyclingRecipes.registerRecyclingRecipes‎(provider, SAMachines.STEAM_ALLOY_SMELTER.asStack(), materialStacks, false, null);
+  }
+  
+}

--- a/src/main/java/com/pansmith/steamadditions/data/recipe/SARecyclingRecipes.java
+++ b/src/main/java/com/pansmith/steamadditions/data/recipe/SARecyclingRecipes.java
@@ -4,6 +4,8 @@ import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialStack;
 
 import com.pansmith.steamadditions.common.data.SAMachines;
 
+import java.util.function.Consumer;
+
 public class SARecyclingRecipes {
 
   public static void init(Consumer<FinishedRecipe> provider) {


### PR DESCRIPTION
FYI:
The calls to `RecyclingRecipes.registerRecyclingRecipes()` are both manual, as I did not see a point to automating them for just two multiblock controllers. If you want to add more multiblocks to the point that automating calls would be more efficient, or want it done via an even more native solution, I would recommend loading the multiblock controllers (+ their associated material lists) directly into `ChemicalHelper.ITEM_MATERIAL_INFO` at registration, which will have GTCEuM do it automatically for you, or otherwise looking at other addons' implementations to find best practices.
Quick question: there is already an import of the entire contents of the `com.pansmith.steamadditions.data.recipe` folder in `SARecipes`, line 3. Is a direct import of each class therein on lines 5 and 6 still necessary after that?